### PR TITLE
Priority for the action_footer action

### DIFF
--- a/jq_img_lazy_load.php
+++ b/jq_img_lazy_load.php
@@ -17,7 +17,7 @@ class jQueryLazyLoad {
 		add_action('wp_enqueue_scripts', array($this, 'action_enqueue_scripts'));
 		add_filter('the_content', array($this, 'filter_the_content'));
 		add_filter('wp_get_attachment_link', array($this, 'filter_the_content'));
-		add_action('wp_footer', array($this, 'action_footer'));
+		add_action('wp_footer', array($this, 'action_footer'), 100);
 	}
 
 	function action_header() {


### PR DESCRIPTION
It might be a good idea to put a priority higher than the one by default(20). It's actually good practice to put javascript in footer but your script might end up loading before jQuery (and that would prevent it to load properly).
